### PR TITLE
Set image width to 100% to prevent images from overflowing on small d…

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -30,6 +30,10 @@ h3 {
     align-self: center;
 }
 
+.image img {
+    width: 100%;
+}
+
 @media (min-width: 900px) {
     .about-us-main-container {
         display: grid;


### PR DESCRIPTION
Set image width to 100% on about page to prevent images from overflowing on small devices.